### PR TITLE
Adds NylasAccount class representing a user account

### DIFF
--- a/nylas-dotnet/AccountDetail.cs
+++ b/nylas-dotnet/AccountDetail.cs
@@ -1,0 +1,19 @@
+﻿namespace nylas_dotnet
+{
+    public class AccountDetail
+    {
+        public string? id { get; set; }
+        public string? account_id { get; set; }
+        public string? name { get; set; }
+        public string? email_address { get; set; }
+        public string? provider { get; set; }
+        public string? organization_unit { get; set; }
+        public string? sync_state { get; set; }
+        public long? linked_at { get; set; }
+
+        public override string ToString()
+        {
+            return $"AccountDetail [id={id}, account_id={account_id}, name={name}, email_address={email_address}, provider={provider}, organization_unit={organization_unit}, sync_state={sync_state}, linked_at={linked_at}]";
+        }
+    }
+}

--- a/nylas-dotnet/NylasAccount.cs
+++ b/nylas-dotnet/NylasAccount.cs
@@ -1,0 +1,41 @@
+﻿
+using Nylas;
+
+namespace nylas_dotnet
+{
+    public class NylasAccount
+    {
+        public NylasClient Client { get; private set; }
+        public string AccessToken { get; private set; }
+
+        public NylasAccount(NylasClient client, string accessToken)
+        {
+            this.Client = client;
+            this.AccessToken = accessToken;
+        }
+
+        /// <summary>
+        /// Calls endpoint /account
+        /// https://developer.nylas.com/docs/api/v2/#get/account
+        /// </summary>
+        /// <returns></returns>
+        public async Task<AccountDetail?> FetchAccountByAccessToken()
+        {
+            Uri url = Client.CreateUrl("account");
+            return await Client.ExecuteGet<AccountDetail>(AccessToken, NylasClient.AuthMethod.BEARER, url);
+        }
+
+
+        /// <summary>
+        /// Calls endpoint /oauth/revoke
+        /// See https://developer.nylas.com/docs/api/v2/#post/oauth/revoke
+        /// </summary>
+        public async Task<bool> RevokeAccessToken()
+        {
+            Uri url = Client.CreateUrl("oauth/revoke");
+            SuccessResponse? response =
+                await Client.ExecutePost<SuccessResponse?>(AccessToken, NylasClient.AuthMethod.BEARER, url, null);
+            return response != null && response.Success;
+        }
+    }
+}

--- a/nylas-dotnet/NylasClient.cs
+++ b/nylas-dotnet/NylasClient.cs
@@ -1,9 +1,15 @@
-﻿namespace Nylas
+﻿using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Nylas
 {
     public class NylasClient
     {
         public static readonly string DEFAULT_BASE_URL = "https://api.nylas.com/";
 	    public static readonly string EU_BASE_URL = "https://ireland.api.nylas.com/";
+
+        public enum AuthMethod { BASIC, BASIC_WITH_CREDENTIALS, BEARER }
+        public enum HttpMethod { GET, PUT, POST, DELETE, PATCH }
 
         public Uri BaseUrl { get; private set; }
         public HttpClient HttpClient { get; private set; } = new HttpClient();
@@ -36,6 +42,86 @@
         internal Uri CreateUrl(string pathSegments)
         {
             return new Uri(BaseUrl, pathSegments);
+        }
+
+        /// <summary>
+        /// Sends a POST request to the specified URL and attempts to deserialize the response as a DTO.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="authUser"></param>
+        /// <param name="authMethod"></param>
+        /// <param name="url"></param>
+        /// <param name="body"></param>
+        /// <returns></returns>
+        public async Task<T?> ExecutePost<T>(string authUser, 
+            AuthMethod authMethod, 
+            Uri url,
+            RequestContent? body)
+        {
+            var payload = body != null ? body.ToStringContent() : new StringContent(string.Empty);
+
+            SetHttpClientHeaders(authUser, authMethod);
+
+            var response = await this.HttpClient.PostAsync(url, payload);
+            
+            return await DeserializeResponse<T>(response);
+        }
+
+        /// <summary>
+        /// Sends a GET request to the specified URL and attempts to deserialize the response as a DTO.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="authUser"></param>
+        /// <param name="authMethod"></param>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        public async Task<T?> ExecuteGet<T>(string authUser,
+            AuthMethod authMethod,
+            Uri url)
+        {
+            SetHttpClientHeaders(authUser, authMethod);
+
+            var response = await this.HttpClient.GetAsync(url);
+
+            return await DeserializeResponse<T>(response);
+        }
+
+        /// <summary>
+        /// Sets the common request headers
+        /// TODO: This assumes that the Content-Type is application/json.
+        /// TODO: This only supports Bearer authentication.
+        /// </summary>
+        /// <param name="authUser"></param>
+        /// <param name="authMethod"></param>
+        private void SetHttpClientHeaders(string authUser, AuthMethod authMethod)
+        {
+            var httpClient = this.HttpClient;
+            httpClient.DefaultRequestHeaders.Accept.Clear();
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            httpClient.DefaultRequestHeaders.Authorization =
+                authMethod switch
+                {
+                    AuthMethod.BEARER => new AuthenticationHeaderValue("Bearer", authUser),
+                    _ => null
+                };
+        }
+
+        /// <summary>
+        /// Attempts to deserialize a HttpResponseMessage as a DTO
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="response"></param>
+        /// <returns></returns>
+        private async Task<T?> DeserializeResponse<T>(HttpResponseMessage response)
+        {
+            T? result = default(T);
+
+            if (response.IsSuccessStatusCode)
+            {
+                result = JsonSerializer.Deserialize<T>(await response.Content.ReadAsStringAsync());
+            }
+
+            return result;
         }
     }
 }

--- a/nylas-dotnet/SuccessResponse.cs
+++ b/nylas-dotnet/SuccessResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace nylas_dotnet
+{
+    internal class SuccessResponse
+    {
+        public bool Success { get; set; }
+    }
+}

--- a/nylas-dotnetTests/NylasAccountTests.cs
+++ b/nylas-dotnetTests/NylasAccountTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nylas;
+using Nylas.Tests;
+
+namespace nylas_dotnet.Tests
+{
+    [TestClass()]
+    public class NylasAccountTests
+    {
+        private NylasClient? _client = null;
+        private string? _clientId;
+        private string? _clientSecret;
+        private string? _accessToken;
+
+        [TestInitialize]
+        public void Init()
+        {
+            var config = new ConfigurationBuilder()
+                .AddUserSecrets<HostedAuthenticationTests>()
+                .Build();
+
+            _clientId = config["client_id"];
+            _clientSecret = config["client_secret"];
+            _accessToken = config["access_token"];
+
+            _client = new NylasClient();
+        }
+
+        [TestMethod()]
+        public void FetchAccountByAccessTokenTest()
+        {
+            // if any members are null then assert fail
+            if (_client == null || _clientId == null || _clientSecret == null || _accessToken == null)
+            {
+                Assert.Fail();
+            }
+
+            NylasAccount account = new NylasAccount(_client, _accessToken);
+            Assert.IsNotNull(account);
+
+            var details = account.FetchAccountByAccessToken().Result;
+            Assert.IsNotNull(details);
+        }
+    }
+}


### PR DESCRIPTION
Adds two primary API actions for a user's account:
* Revoke the access token
* Return the account details

A unit test is included to get the account details and is dependent on proper settings in the secrets.json file locally.